### PR TITLE
Add .env files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .DS_Store
 _images/.DS_Store
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local


### PR DESCRIPTION
This PR adds environment variable files to the .gitignore to prevent accidental commit of sensitive configuration data.

Added patterns:
- `.env`
- `.env.local`
- `.env.development.local`
- `.env.test.local`
- `.env.production.local`

This follows security best practices by ensuring environment files containing API keys, database credentials, and other sensitive data are not tracked in version control.